### PR TITLE
Bind the stack to struct in handler.Run().

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -533,6 +533,8 @@ func (h *Handler) Run(stack *[]reflect.Value, args []string, context map[string]
 	}
 	*stack = append(*stack, value)
 
+	h.bindStackToStruct(*stack, value)
+
 	if len(args) > 0 {
 		enter := h.findEnterFunc(h.OptionType)
 		if enter != nil {
@@ -690,4 +692,3 @@ func (h *Handler) Bind(ptr reflect.Value, args []string) (err error) {
 	}
 	return nil
 }
-


### PR DESCRIPTION
When `flagly.Run(*struct)` is called the handler currently isn't binding `flagly:"parent"` fields to their parent type.

This PR fixes that by calling `handler.bindStackToStruct()` in `handler.Run()` so these fields are populated.